### PR TITLE
jQuery compatible manipulation functions - allow passing text.

### DIFF
--- a/src/manipulation/after.ts
+++ b/src/manipulation/after.ts
@@ -1,6 +1,6 @@
 
 // @require core/cash.ts
-// @require ./helpers/insert_selectors.ts
+// @require ./helpers/insert_content.ts
 
 interface Cash {
   after ( ...selectors: Selector[] ): this;
@@ -8,6 +8,6 @@ interface Cash {
 
 fn.after = function ( this: Cash ) {
 
-  return insertSelectors ( arguments, this, false, false, false, true, true );
+  return insertContent ( arguments, this, false, false, false, true, true );
 
 };

--- a/src/manipulation/append.ts
+++ b/src/manipulation/append.ts
@@ -1,6 +1,6 @@
 
 // @require core/cash.ts
-// @require ./helpers/insert_selectors.ts
+// @require ./helpers/insert_content.ts
 
 interface Cash {
   append ( ...selectors: Selector[] ): this;
@@ -8,6 +8,6 @@ interface Cash {
 
 fn.append = function ( this: Cash ) {
 
-  return insertSelectors ( arguments, this, false, false, true );
+  return insertContent ( arguments, this, false, false, true );
 
 };

--- a/src/manipulation/before.ts
+++ b/src/manipulation/before.ts
@@ -1,6 +1,6 @@
 
 // @require core/cash.ts
-// @require ./helpers/insert_selectors.ts
+// @require ./helpers/insert_content.ts
 
 interface Cash {
   before ( ...selectors: Selector[] ): this;
@@ -8,6 +8,6 @@ interface Cash {
 
 fn.before = function ( this: Cash ) {
 
-  return insertSelectors ( arguments, this, false, true );
+  return insertContent ( arguments, this, false, true );
 
 };

--- a/src/manipulation/helpers/insert_content.ts
+++ b/src/manipulation/helpers/insert_content.ts
@@ -1,0 +1,12 @@
+
+// @require ./insert_selectors.ts
+
+function insertContent<T extends ArrayLike<EleLoose> = ArrayLike<EleLoose>> ( selectors: ArrayLike<Selector>, anchors: T, inverse?: boolean, left?: boolean, inside?: boolean, reverseLoop1?: boolean, reverseLoop2?: boolean, reverseLoop3?: boolean ): T {
+
+  if (!isCash ( selectors ) && isString ( selectors[0] ) && !htmlRe.test ( selectors[0] )) {
+    arguments[0] = [doc.createTextNode(selectors[0])];
+  }
+
+  return insertSelectors ( ...arguments );
+
+}

--- a/src/manipulation/prepend.ts
+++ b/src/manipulation/prepend.ts
@@ -1,6 +1,6 @@
 
 // @require core/cash.ts
-// @require ./helpers/insert_selectors.ts
+// @require ./helpers/insert_content.ts
 
 interface Cash {
   prepend ( ...selectors: Selector[] ): this;
@@ -8,6 +8,6 @@ interface Cash {
 
 fn.prepend = function ( this: Cash ) {
 
-  return insertSelectors ( arguments, this, false, true, true, true, true );
+  return insertContent ( arguments, this, false, true, true, true, true );
 
 };

--- a/test/modules/manipulation.js
+++ b/test/modules/manipulation.js
@@ -83,6 +83,14 @@ describe ( 'Manipulation', { beforeEach: getFixtureInit ( fixture ) }, function 
 
     });
 
+    it ( 'inserts a text after', function ( t ) {
+
+      $('.parent .anchor').after('text');
+
+      t.is($('.parent').html().trim(), '<div class="anchor">content</div>text');
+
+    });
+
     it ( 'supports non-element nodes', function ( t ) {
 
       var ele = $('<div><span> dear</span>world</div>');
@@ -120,6 +128,14 @@ describe ( 'Manipulation', { beforeEach: getFixtureInit ( fixture ) }, function 
       t.is ( prev.length, 0 );
       t.is ( next.length, 3 );
       t.deepEqual ( $('.parent').children ().slice ( 1 ).get ().map ( ele2tagname ), ['A', 'B', 'C'] );
+
+    });
+
+    it ( 'appends text', function ( t ) {
+
+      $('.parent').append('text');
+
+      t.is($('.parent').html().trim(), '<div class=\"anchor\">content</div>  text');
 
     });
 
@@ -185,6 +201,14 @@ describe ( 'Manipulation', { beforeEach: getFixtureInit ( fixture ) }, function 
       t.is ( prev.length, 3 );
       t.is ( next.length, 0 );
       t.deepEqual ( $('.parent').children ().slice ( 0, 3 ).get ().map ( ele2tagname ), ['A', 'B', 'C'] );
+
+    });
+
+    it ( 'inserts a text before', function ( t ) {
+
+      $('.parent .anchor').before('text');
+
+      t.is($('.parent').html().trim(), 'text<div class=\"anchor\">content</div>');
 
     });
 
@@ -413,6 +437,14 @@ describe ( 'Manipulation', { beforeEach: getFixtureInit ( fixture ) }, function 
 
     });
 
+    it ( 'prepends a text', function ( t ) {
+
+      $('.parent').prepend('text');
+
+      t.is($('.parent').html().trim(), 'text    <div class=\"anchor\">content</div>');
+
+    });
+
     it ( 'supports non-element nodes', function ( t ) {
 
       var ele = $('<div>world</div>');
@@ -527,6 +559,14 @@ describe ( 'Manipulation', { beforeEach: getFixtureInit ( fixture ) }, function 
       t.is ( parent.html ().trim (), html );
       t.is ( $('.anchor').length, 0 );
       t.is ( $('.parent p').length, 1 );
+
+    });
+
+    it ( 'replaces node with a text', function ( t ) {
+
+      $('.parent .anchor').replaceWith('text');
+
+      t.is($('.parent').html().trim(), 'text');
 
     });
 


### PR DESCRIPTION
This PR fixes the ability to pass text to the following functions:

- after
- append
- before
- prepend
- replaceWith

This is a known and documented difference:
- Issue: https://github.com/fabiospampinato/cash/issues/275
- Documentation: https://github.com/fabiospampinato/cash/blob/master/docs/migration_guide.md#manipulation

This is a BC to the Cash library, so version 9.0 is coming.